### PR TITLE
chore: configure GitHub Pages base path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command, mode }) => ({
-  base: command === "build" ? "/print-first-poster/" : "/",
+  base: command === "build" ? "/print-first-qr-card/" : "/",
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- configure the Vite base path for the print-first-qr-card repository name
- keep the existing Pages workflow intact

## Validation
- npm run build
- git diff --check

## Summary by Sourcery

Build:
- Update Vite base URL used for production builds to "/print-first-qr-card/" for GitHub Pages hosting.